### PR TITLE
Dependency updates | Kotlin 1.4.30, Ktor 1.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,12 @@ buildscript {
         ]
 
         setup = [
-                kotlin    : '1.4.21-2',
+                kotlin    : '1.4.30',
                 compileSdk: 30,
                 buildTools: "30.0.2",
                 minSdk    : 21,
                 targetSdk : 30,
-                dokka     : "1.4.20-multimodule-dev-7"
+                dokka     : "1.4.20.2-dev-64"
         ]
 
         versions = [
@@ -24,18 +24,18 @@ buildscript {
                 constraintLayout    : '2.0.4',
                 cardView            : '1.0.0',
                 okhttp              : '4.9.1',
-                iconics             : "5.2.5",
+                iconics             : "5.2.6",
                 fastadapter         : '5.3.4',
-                materialdrawer      : '8.3.2',
-                aboutLibraries      : '8.8.1',
-                ktor                : "1.5.0",
+                materialdrawer      : '8.3.3',
+                aboutLibraries      : '8.8.2',
+                ktor                : "1.5.1",
                 kermit              : "0.1.8",
                 kotlinxSerialization: "1.0.1",
                 kotlinCoroutines    : "1.4.2-native-mt",
                 // ktx
-                activityKtx         : "1.1.0",
-                lifecycleKtx        : "2.2.0",
-                viewModelKtx        : "2.2.0",
+                activityKtx         : "1.2.0",
+                lifecycleKtx        : "2.3.0",
+                viewModelKtx        : "2.3.0",
                 // other
                 detekt              : '1.15.0',
         ]
@@ -49,7 +49,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha05'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha07'
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${setup.kotlin}"
         classpath "org.jetbrains.kotlin:kotlin-serialization:${setup.kotlin}"


### PR DESCRIPTION
- update to kotlin 1.4.30
- update to dokka 1.4.20.2-dev-64
- update to iconics 5.2.6
- update to materialdrawer 8.3.3
- update to aboutlibraries 8.8.2
- update to ktor 1.5.1
- update to activity 1.2.0
- update to lifecycle, viewModel 2.3.0
- update gradle build tools to alpha07