### PR TITLE
Upgrade dependencies to latest stable releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
                 buildTools: "31.0.0",
                 minSdk    : 21,
                 targetSdk : 30,
-                dokka     : "1.5.31"
+                dokka     : "1.6.0"
         ]
 
         versions = [
@@ -21,16 +21,16 @@ buildscript {
                 appcompat           : '1.3.1',
                 recyclerView        : '1.2.1',
                 drawerlayout        : '1.1.1',
-                constraintLayout    : '2.1.1',
+                constraintLayout    : '2.1.2',
                 cardView            : '1.0.0',
-                okhttp              : '4.9.2',
-                iconics             : "5.3.2",
-                fastadapter         : '5.5.1',
-                materialdrawer      : '9.0.0-a01',
-                aboutLibraries      : '10.0.0-a01',
-                ktor                : "1.6.5",
+                okhttp              : '4.9.3',
+                iconics             : "5.3.3",
+                fastadapter         : '5.6.0',
+                materialdrawer      : '9.0.0-a03',
+                aboutLibraries      : '10.0.0-b02',
+                ktor                : "1.6.6",
                 kermit              : "0.3.0-m1",
-                kotlinxSerialization: "1.3.0",
+                kotlinxSerialization: "1.3.1",
                 kotlinxDateTime     : "0.3.1",
                 kotlinCoroutines    : "1.5.2",
                 // ktx
@@ -38,7 +38,7 @@ buildscript {
                 lifecycleKtx        : "2.4.0",
                 viewModelKtx        : "2.4.0",
                 // other
-                detekt              : '1.18.1',
+                detekt              : '1.19.0',
         ]
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- upgrade dependencies 
  - dokka 1.6.0
  - constraintLayout 2.1.2
  - okhttp 4.9.3
  - iconics 5.3.3
  - fastAdapter 5.6.0
  - materialDrawer 9.0.0-a03
  - AboutLibraries 10.0.0-b02
  - kotlinxSerialization 1.3.1