### PR TITLE
Revert ktor to 1.6.5 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
                 fastadapter         : '5.6.0',
                 materialdrawer      : '9.0.0-a03',
                 aboutLibraries      : '10.0.0-b02',
-                ktor                : "1.6.6",
+                ktor                : "1.6.5",
                 kermit              : "1.0.2",
                 kotlinxSerialization: "1.3.1",
                 kotlinxDateTime     : "0.3.1",

--- a/storyblok-mp-sdk/build.gradle
+++ b/storyblok-mp-sdk/build.gradle
@@ -51,7 +51,7 @@ kotlin {
     watchosArm32()
     watchosArm64()
     macosX64()
-    macosArm64()
+    // macosArm64()
     mingwX64()
     linuxX64()
 
@@ -71,7 +71,7 @@ kotlin {
         linuxX64Main { dependsOn(desktopMain) }
         mingwX64Main { dependsOn(desktopMain) }
         macosX64Main { dependsOn(desktopMain) }
-        macosArm64Main { dependsOn(desktopMain) }
+        // macosArm64Main { dependsOn(desktopMain) }
 
         iosMain { dependsOn(commonMain) }
         iosArm64Main { dependsOn(iosMain) }


### PR DESCRIPTION
- curl client does not support macosArm64
- revert to ktor 1.6.5