### PR TITLE
Adjust API to pass in `filter_query` to fetch stories

### DIFF
--- a/storyblok-mp-sdk/src/commonMain/kotlin/com/mikepenz/storyblok/sdk/Storyblok.kt
+++ b/storyblok-mp-sdk/src/commonMain/kotlin/com/mikepenz/storyblok/sdk/Storyblok.kt
@@ -178,7 +178,7 @@ class Storyblok constructor(
         fromRelease: Long? = null,
         sortBy: Array<String>? = null,
         searchTerm: String? = null,
-        filterQuery: String? = null,
+        filterQuery: Map<String, String>? = null,
         isStartpage: Boolean? = null,
         withTag: Array<String>? = null,
         page: Int = 1,
@@ -197,7 +197,9 @@ class Storyblok constructor(
             parameter("from_release", fromRelease)
             parameter("sort_by", sortBy)
             parameter("search_term", searchTerm)
-            parameter("filter_query", filterQuery)
+            filterQuery?.forEach { (key, value) ->
+                parameter("filter_query$key", value)
+            }
             parameter("is_startpage", isStartpage)
             parameter("with_tag", withTag)
             parameter("page", page)


### PR DESCRIPTION
- adjust `filter_query` API to allow passing in queries
  - FIX https://github.com/mikepenz/storyblok-mp-SDK/issues/70
```
storyblok.fetchStories(filterQuery = mapOf("[_uid][like]" to "*413*", "[layout][like]" to "relative"))
```