### PR TITLE
Retrieve `relations` and `links` via the Story APi

### DIFF
--- a/sample-common/src/commonMain/kotlin/com/mikepenz/common/repository/StoryblokRepository.kt
+++ b/sample-common/src/commonMain/kotlin/com/mikepenz/common/repository/StoryblokRepository.kt
@@ -12,7 +12,7 @@ class StoryblokRepository(token: String) {
 
     suspend fun fetchStories(): List<Story> {
         logger.d("Repo")
-        return storyblok.fetchStories()
+        return storyblok.fetchStories().stories
     }
 }
 

--- a/storyblok-mp-sdk/src/commonMain/kotlin/com/mikepenz/storyblok/sdk/Storyblok.kt
+++ b/storyblok-mp-sdk/src/commonMain/kotlin/com/mikepenz/storyblok/sdk/Storyblok.kt
@@ -109,7 +109,7 @@ class Storyblok constructor(
         language: String? = null,
         fallbackLang: String? = null,
         cv: Long? = null
-    ): Story? {
+    ): StoryWrapper {
         val story: StoryWrapper = client.get(buildUrl(ENDPOINT_STORIES, key), requestBuilder {
             parameter("find_by", findBy)
             parameter("resolve_links", resolveLinks)
@@ -119,7 +119,7 @@ class Storyblok constructor(
             parameter("fallback_lang", fallbackLang)
             parameter("cv", cv)
         })
-        return story.story
+        return story
     }
 
     /**
@@ -184,7 +184,7 @@ class Storyblok constructor(
         page: Int = 1,
         perPage: Int = 25,
         cv: Long? = null
-    ): List<Story> {
+    ): StoriesWrapper {
         val storyList: StoriesWrapper = client.get(buildUrl(ENDPOINT_STORIES), requestBuilder {
             parameter("starts_with", startsWith)
             parameter("by_uuids", byUuids)
@@ -206,7 +206,7 @@ class Storyblok constructor(
             parameter("per_page", perPage)
             parameter("cv", cv)
         })
-        return storyList.stories ?: emptyList()
+        return storyList
     }
 
     /**

--- a/storyblok-mp-sdk/src/commonMain/kotlin/com/mikepenz/storyblok/sdk/model/Story.kt
+++ b/storyblok-mp-sdk/src/commonMain/kotlin/com/mikepenz/storyblok/sdk/model/Story.kt
@@ -67,12 +67,86 @@ data class Story(
     val lang: String = "default"
 )
 
+/**
+ * Represents the returned story and respective additional attributes if configured.
+ * See [cv], [relations], [links], [relationUuids], [linkUuids]
+ *
+ * Please see the documentation of [com.mikepenz.storyblok.sdk.Storyblok.fetchStory].
+ */
 @Serializable
-internal class StoryWrapper {
+class StoryWrapper {
+    /**
+     * The cache version
+     */
+    val cv: Long? = null
+
+    /**
+     * 	A single [Story] object
+     */
     val story: Story? = null
+
+    /**
+     * Array of related [Story] objects when using the resolve_relations parameter
+     */
+    @SerialName("rels")
+    val relations: List<Story> = emptyList()
+
+    /**
+     * Array of the uuids of all the related story objects if the resolve_relations parameter is in use and if the limit of resolvable relations is hit
+     */
+    @SerialName("rel_uuids")
+    val relationUuids: List<String> = emptyList()
+
+    /**
+     * Array of [Link] or story objects when using the resolve_links parameter
+     */
+    val links: List<Link> = emptyList()
+
+    /**
+     * Array of the uuids of all the links if the resolve_links parameter is in use and if the limit of resolvable links is hit
+     */
+    @SerialName("link_uuids")
+    val linkUuids: List<String> = emptyList()
 }
 
+/**
+ * Represents the returned list of stories and respective additional attributes if configured.
+ * See [cv], [relations], [links], [relationUuids], [linkUuids]
+ *
+ * Please see the documentation of [com.mikepenz.storyblok.sdk.Storyblok.fetchStories].
+ */
 @Serializable
-internal class StoriesWrapper {
+class StoriesWrapper {
+    /**
+     * The cache version
+     */
+    val cv: Long? = null
+
+    /**
+     * An array of [Story] objects
+     */
     val stories: List<Story> = emptyList()
+
+    /**
+     * Array of related [Story] objects when using the resolve_relations parameter
+     */
+    @SerialName("rels")
+    val relations: List<Story> = emptyList()
+
+    /**
+     * Array of the uuids of all the related story objects if the resolve_relations parameter is in use and if the limit of resolvable relations is hit
+     */
+    @SerialName("rel_uuids")
+    val relationUuids: List<String> = emptyList()
+
+    /**
+     * Array of [Link] or [Story] objects when using the resolve_links parameter
+     */
+    val links: List<Story> = emptyList()
+
+    /**
+     * Array of the uuids of all the links if the resolve_links parameter is in use and if the limit of resolvable links is hit
+     */
+    @SerialName("link_uuids")
+    val linkUuids: List<String> = emptyList()
 }


### PR DESCRIPTION
- expand the API of `fetchStory` and `fetchStories` to also contain the additional metaData returned
  - relations, links
  - FIX https://github.com/mikepenz/storyblok-mp-SDK/issues/72